### PR TITLE
Depend on python3 in .deb packages

### DIFF
--- a/mysql-shell_builder.sh
+++ b/mysql-shell_builder.sh
@@ -931,7 +931,7 @@ build_source_deb(){
     sed -i 's|Package: mysql-shell|Package: percona-mysql-shell|' debian/control
     sed -i 's|cmake (>= 2.8.5), ||' debian/control
     sed -i 's|mysql-shell|percona-mysql-shell|' debian/changelog
-    sed -i 's|${misc:Depends},|${misc:Depends}, python2.7|' debian/control
+    sed -i 's|${misc:Depends},|${misc:Depends}, python3|' debian/control
     sed -i 's|(>=0.9.2)||' debian/control
     sed -i 's|libssh-dev ,||' debian/control
     sed -i '17d' debian/control


### PR DESCRIPTION
`python2.7` is no longer supported by Ubuntu (at least) and per [0], mysql-shell now uses Python 3.

[0] https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-features.html